### PR TITLE
Protocol improvements

### DIFF
--- a/src/dnd/components.rs
+++ b/src/dnd/components.rs
@@ -502,6 +502,12 @@ impl AppNotification {
         self.revealer.set_reveal_child(true);
     }
 
+    pub fn hide(&self, main_overlay: &gtk::Overlay) {
+        main_overlay.reorder_overlay(&self.overlay, 0);
+
+        self.revealer.set_reveal_child(false)
+    }
+
     pub fn show_text(&self, overlay: &gtk::Overlay, text: &str) {
         self.label.set_text(text);
         self.reveal(overlay);

--- a/src/dnd/mod.rs
+++ b/src/dnd/mod.rs
@@ -59,12 +59,17 @@ pub fn build_window(
     let window_weak = window.downgrade();
     gtk_receiver.attach(None, move |values| match values {
         PeerEvent::TransferProgress((v, t, direction)) => {
+            alert_notif.hide(&overlay);
             let size = v as f64;
             let total = t as f64;
             match direction {
                 Direction::Incoming => progress.show_incoming(&overlay, size, total),
                 Direction::Outgoing => progress.show_outgoing(&overlay, size, total),
             }
+            Continue(true)
+        }
+        PeerEvent::WaitingForAnswer => {
+            alert_notif.show_text(&overlay, "Waiting for answer from the other device...");
             Continue(true)
         }
         PeerEvent::TransferCompleted => {
@@ -143,6 +148,8 @@ pub fn start_window() {
     let peer_receiver_arc = Arc::new(Mutex::new(peer_receiver));
 
     let name = "com.sireliah.Dragit";
+
+    info!("Starting {}", name);
 
     let application = gtk::Application::new(Some(&name), gio::ApplicationFlags::empty())
         .expect("Initialization failed...");

--- a/src/dnd/mod.rs
+++ b/src/dnd/mod.rs
@@ -72,6 +72,10 @@ pub fn build_window(
             alert_notif.show_text(&overlay, "Waiting for answer from the other device...");
             Continue(true)
         }
+        PeerEvent::TransferRejected => {
+            alert_notif.show_text(&overlay, "Payload was rejected");
+            Continue(true)
+        }
         PeerEvent::TransferCompleted => {
             progress.hide(&overlay);
             Continue(true)

--- a/src/p2p/discovery/behaviour.rs
+++ b/src/p2p/discovery/behaviour.rs
@@ -18,11 +18,6 @@ use crate::p2p::discovery::handler::KeepAliveHandler;
 use crate::p2p::discovery::protocol::{Discovery, DiscoveryEvent};
 use crate::p2p::peer::{CurrentPeers, OperatingSystem, Peer, PeerEvent};
 
-// #[derive(Debug)]
-// pub enum InnerMessage {
-//     Received(Discovery),
-//     Sent(Discovery),
-// }
 
 #[derive(Debug)]
 pub struct InnerMessage(Discovery);

--- a/src/p2p/discovery/protocol.rs
+++ b/src/p2p/discovery/protocol.rs
@@ -7,14 +7,11 @@ use prost::Message;
 use super::proto::Host;
 
 use crate::p2p::peer::OperatingSystem;
+use crate::p2p::util::TSocketAlias;
 
 type DiscoverySuccess = (String, OperatingSystem);
 type DiscoveryFailure = io::Error;
 pub type DiscoveryResult = Result<DiscoverySuccess, DiscoveryFailure>;
-
-// Convenience trait implementation, which helps to alias socket type
-trait TSocketAlias: AsyncRead + AsyncWrite + Send + Unpin {}
-impl<T: AsyncRead + AsyncWrite + Send + Unpin> TSocketAlias for T {}
 
 #[derive(Debug)]
 pub struct DiscoveryEvent {

--- a/src/p2p/discovery/protocol.rs
+++ b/src/p2p/discovery/protocol.rs
@@ -12,6 +12,10 @@ type DiscoverySuccess = (String, OperatingSystem);
 type DiscoveryFailure = io::Error;
 pub type DiscoveryResult = Result<DiscoverySuccess, DiscoveryFailure>;
 
+// Convenience trait implementation, which helps to alias socket type
+trait TSocketAlias: AsyncRead + AsyncWrite + Send + Unpin {}
+impl<T: AsyncRead + AsyncWrite + Send + Unpin> TSocketAlias for T {}
+
 #[derive(Debug)]
 pub struct DiscoveryEvent {
     pub peer: PeerId,
@@ -52,6 +56,57 @@ impl UpgradeInfo for Discovery {
     }
 }
 
+async fn read_peer(
+    mut socket: impl TSocketAlias,
+) -> Result<(Discovery, impl TSocketAlias), io::Error> {
+    let data = match upgrade::read_one(&mut socket, 1024).await {
+        Ok(value) => value,
+        Err(err) => match err {
+            upgrade::ReadOneError::Io(e) => {
+                error!("IO error: {:?}", e);
+                return Err(e);
+            }
+            upgrade::ReadOneError::TooLarge {
+                requested: _,
+                max: _,
+            } => {
+                error!("Payload too large!");
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "Payload too large",
+                ));
+            }
+        },
+    };
+    let host = Host::decode(&data[..])?;
+    let os = match OperatingSystem::from_i32(host.os) {
+        Some(v) => v,
+        None => OperatingSystem::Unknown,
+    };
+    let discovery = Discovery {
+        hostname: host.hostname,
+        os,
+    };
+    Ok((discovery, socket))
+}
+
+async fn write_peer(
+    hostname: String,
+    os: OperatingSystem,
+    mut socket: impl TSocketAlias,
+) -> Result<impl TSocketAlias, io::Error> {
+    let proto = Host {
+        hostname,
+        os: os as i32,
+    };
+    let mut buf = Vec::with_capacity(proto.encoded_len());
+
+    proto.encode(&mut buf)?;
+    upgrade::write_one(&mut socket, buf).await?;
+
+    Ok(socket)
+}
+
 impl<TSocket> InboundUpgrade<TSocket> for Discovery
 where
     TSocket: AsyncRead + AsyncWrite + Send + Unpin + 'static,
@@ -60,37 +115,14 @@ where
     type Error = io::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
-    fn upgrade_inbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
-        // Receiving the (dialer) host data from remote.
+    fn upgrade_inbound(self, socket: TSocket, _info: Self::Info) -> Self::Future {
+        // (As dialer) receiving the host data from remote
+        // and sending own data immediately after
         Box::pin(async move {
-            let data = match upgrade::read_one(&mut socket, 1024).await {
-                Ok(value) => value,
-                Err(err) => match err {
-                    upgrade::ReadOneError::Io(e) => {
-                        error!("IO error: {:?}", e);
-                        return Err(e);
-                    }
-                    upgrade::ReadOneError::TooLarge {
-                        requested: _,
-                        max: _,
-                    } => {
-                        error!("Payload too large!");
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "Payload too large",
-                        ));
-                    }
-                },
-            };
-            let host = Host::decode(&data[..])?;
-            let os = match OperatingSystem::from_i32(host.os) {
-                Some(v) => v,
-                None => OperatingSystem::Unknown,
-            };
-            Ok(Discovery {
-                hostname: host.hostname,
-                os,
-            })
+            let (discovery, socket) = read_peer(socket).await?;
+            let _ = write_peer(self.hostname, self.os, socket).await?;
+
+            Ok(discovery)
         })
     }
 }
@@ -99,22 +131,17 @@ impl<TSocket> OutboundUpgrade<TSocket> for Discovery
 where
     TSocket: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
-    type Output = ();
+    type Output = Discovery;
     type Error = io::Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
 
-    fn upgrade_outbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
-        // Sending the (listener) host data to remote.
+    fn upgrade_outbound(self, socket: TSocket, _info: Self::Info) -> Self::Future {
+        // (As listener) sending the host data to remote
+        // and receiving remote host data in exchange
         Box::pin(async move {
-            let proto = Host {
-                hostname: self.hostname,
-                os: self.os as i32,
-            };
-            let mut buf = Vec::with_capacity(proto.encoded_len());
-
-            proto.encode(&mut buf)?;
-            upgrade::write_one(&mut socket, buf).await?;
-            Ok(())
+            let socket = write_peer(self.hostname, self.os, socket).await?;
+            let (discovery, _) = read_peer(socket).await?;
+            Ok(discovery)
         })
     }
 }

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -46,6 +46,7 @@ impl Into<bool> for PayloadAccepted {
 pub enum PeerEvent {
     PeersUpdated(CurrentPeers),
     WaitingForAnswer,
+    TransferRejected,
     TransferProgress((usize, usize, Direction)),
     TransferCompleted,
     FileCorrect(String, Payload),

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -17,9 +17,35 @@ pub enum TransferType {
     Text = 1,
 }
 
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Enumeration)]
+pub enum PayloadAccepted {
+    Yes = 1,
+    No = 2,
+}
+
+/// Mappings for protobuf conversion
+impl From<bool> for PayloadAccepted {
+    fn from(accepted: bool) -> PayloadAccepted {
+        match accepted {
+            true => PayloadAccepted::Yes,
+            false => PayloadAccepted::No,
+        }
+    }
+}
+
+impl Into<bool> for PayloadAccepted {
+    fn into(self) -> bool {
+        match self {
+            PayloadAccepted::Yes => true,
+            PayloadAccepted::No => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum PeerEvent {
     PeersUpdated(CurrentPeers),
+    WaitingForAnswer,
     TransferProgress((usize, usize, Direction)),
     TransferCompleted,
     FileCorrect(String, Payload),

--- a/src/p2p/peer.rs
+++ b/src/p2p/peer.rs
@@ -17,31 +17,6 @@ pub enum TransferType {
     Text = 1,
 }
 
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Enumeration)]
-pub enum PayloadAccepted {
-    Yes = 1,
-    No = 2,
-}
-
-/// Mappings for protobuf conversion
-impl From<bool> for PayloadAccepted {
-    fn from(accepted: bool) -> PayloadAccepted {
-        match accepted {
-            true => PayloadAccepted::Yes,
-            false => PayloadAccepted::No,
-        }
-    }
-}
-
-impl Into<bool> for PayloadAccepted {
-    fn into(self) -> bool {
-        match self {
-            PayloadAccepted::Yes => true,
-            PayloadAccepted::No => false,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub enum PeerEvent {
     PeersUpdated(CurrentPeers),

--- a/src/p2p/transfer/metadata.proto
+++ b/src/p2p/transfer/metadata.proto
@@ -15,6 +15,16 @@ message Metadata {
     TransferType transfer_type = 4;
 }
 
+enum PayloadAccepted {
+    // Protobuf 3 uses default values for both booleans and enums,
+    // and that means that first value in enum is de facto 0 bytes.
+    // The DEFAULT enum option here forces protobuf to send constant amount of bytes.
+    // https://developers.google.com/protocol-buffers/docs/proto3#default
+    DEFAULT = 0;
+    YES = 1;
+    NO = 2;
+}
+
 message Answer {
-    bool accepted = 1;
+    PayloadAccepted accepted = 1;
 }

--- a/src/p2p/transfer/metadata.proto
+++ b/src/p2p/transfer/metadata.proto
@@ -15,16 +15,13 @@ message Metadata {
     TransferType transfer_type = 4;
 }
 
-enum PayloadAccepted {
-    // Protobuf 3 uses default values for both booleans and enums,
-    // and that means that first value in enum is de facto 0 bytes.
-    // The DEFAULT enum option here forces protobuf to send constant amount of bytes.
-    // https://developers.google.com/protocol-buffers/docs/proto3#default
-    DEFAULT = 0;
-    YES = 1;
-    NO = 2;
-}
-
 message Answer {
-    PayloadAccepted accepted = 1;
+    // Protobuf 3 uses default values for different data types, including bools.
+    // This means that "true" value is encoded using 2 bytes, but "false" is 0 bytes.
+    // Sending 0 bytes over the socket is problematic, that's why extra field "hash"
+    // was added here. Removing the field will likely cause your connection to hang.
+    //
+    // https://developers.google.com/protocol-buffers/docs/proto3#default
+    bool accepted = 1;
+    string hash = 2;
 }

--- a/src/p2p/transfer/protocol.rs
+++ b/src/p2p/transfer/protocol.rs
@@ -243,9 +243,12 @@ impl TransferOut {
         let (sender, receiver) = sync_channel::<Vec<u8>>(CHUNK_SIZE * 128);
         info!("File to send: {}", self.file);
 
+        util::notify_waiting(&self.sender_queue).await;
+
         let (size, socket): (usize, TSocket) =
             Metadata::write::<TSocket>(&self.file, socket).await?;
 
+        // Check if remote is willing to accept our file
         let (accepted, socket) = Answer::read::<TSocket>(socket).await?;
         info!("File accepted? {:?}", accepted);
 

--- a/src/p2p/transfer/protocol.rs
+++ b/src/p2p/transfer/protocol.rs
@@ -302,6 +302,7 @@ impl TransferOut {
             util::notify_completed(&self.sender_queue).await;
             Ok(())
         } else {
+            util::notify_rejected(&self.sender_queue).await;
             Ok(())
         }
     }

--- a/src/p2p/transfer/protocol.rs
+++ b/src/p2p/transfer/protocol.rs
@@ -22,7 +22,7 @@ use crate::p2p::peer::{Direction, PeerEvent};
 use crate::p2p::transfer::file::{get_hash_from_payload, FileToSend, Payload};
 use crate::p2p::transfer::jobs;
 use crate::p2p::transfer::metadata::{Answer, Metadata};
-use crate::p2p::util::{self, CHUNK_SIZE};
+use crate::p2p::util::{self, TSocketAlias, CHUNK_SIZE};
 use crate::user_data;
 
 #[derive(Clone, Debug)]
@@ -106,7 +106,7 @@ impl TransferPayload {
 
     async fn read_file_payload(
         &mut self,
-        socket: impl AsyncRead + AsyncWrite + Send + Unpin,
+        socket: impl TSocketAlias,
         meta: &Metadata,
         size: usize,
         direction: &Direction,
@@ -169,12 +169,9 @@ impl TransferPayload {
         Ok((counter, path))
     }
 
-    async fn read_socket<TSocket>(&mut self, socket: TSocket) -> Result<(), io::Error>
-    where
-        TSocket: AsyncRead + AsyncWrite + Send + Unpin,
-    {
+    async fn read_socket(&mut self, socket: impl TSocketAlias) -> Result<(), io::Error> {
         let direction = Direction::Incoming;
-        let (meta, mut socket): (Metadata, TSocket) = Metadata::read::<TSocket>(socket).await?;
+        let (meta, mut socket) = Metadata::read(socket).await?;
         info!("Meta received! \n{}", meta);
 
         self.notify_incoming_file_event(&meta).await;
@@ -182,7 +179,7 @@ impl TransferPayload {
 
         match self.block_for_answer(rec_cp).await {
             TransferCommand::Accept(hash) if hash == meta.hash => {
-                Answer::write(&mut socket, true).await?;
+                Answer::write(&mut socket, true, hash).await?;
 
                 util::notify_progress(&self.sender_queue, 0, meta.size, &direction).await;
 
@@ -210,7 +207,7 @@ impl TransferPayload {
             }
             TransferCommand::Accept(hash) => {
                 warn!("Accepted hash does not match: {} {}", hash, meta.hash);
-                Answer::write(&mut socket, false).await?;
+                Answer::write(&mut socket, false, hash).await?;
                 Err(io::Error::new(
                     ErrorKind::PermissionDenied,
                     "Hash does not match",
@@ -218,7 +215,7 @@ impl TransferPayload {
             }
             TransferCommand::Deny(hash) => {
                 warn!("Denied hash: {}", hash);
-                Answer::write(&mut socket, false).await?;
+                Answer::write(&mut socket, false, hash).await?;
                 Err(io::Error::new(ErrorKind::PermissionDenied, "Rejected"))
             }
         }
@@ -235,21 +232,17 @@ impl UpgradeInfo for TransferPayload {
 }
 
 impl TransferOut {
-    async fn write_socket<TSocket>(&self, socket: TSocket) -> Result<(), io::Error>
-    where
-        TSocket: AsyncRead + AsyncWrite + Send + Unpin,
-    {
+    async fn write_socket(&self, socket: impl TSocketAlias) -> Result<(), io::Error> {
         let direction = Direction::Outgoing;
         let (sender, receiver) = sync_channel::<Vec<u8>>(CHUNK_SIZE * 128);
         info!("File to send: {}", self.file);
 
         util::notify_waiting(&self.sender_queue).await;
 
-        let (size, socket): (usize, TSocket) =
-            Metadata::write::<TSocket>(&self.file, socket).await?;
+        let (size, socket) = Metadata::write(&self.file, socket).await?;
 
         // Check if remote is willing to accept our file
-        let (accepted, socket) = Answer::read::<TSocket>(socket).await?;
+        let (accepted, socket) = Answer::read(socket).await?;
         info!("File accepted? {:?}", accepted);
 
         if accepted {

--- a/src/p2p/util.rs
+++ b/src/p2p/util.rs
@@ -36,6 +36,13 @@ pub async fn notify_completed(sender_queue: &AsyncSender<PeerEvent>) {
         .await;
 }
 
+pub async fn notify_waiting(sender_queue: &AsyncSender<PeerEvent>) {
+    sender_queue
+        .to_owned()
+        .send(PeerEvent::WaitingForAnswer)
+        .await;
+}
+
 pub fn time_to_notify(current_size: usize, total_size: usize) -> bool {
     if current_size >= ((total_size / 10) + CHUNK_SIZE * 256) {
         true

--- a/src/p2p/util.rs
+++ b/src/p2p/util.rs
@@ -1,6 +1,7 @@
 use std::io::{Error, ErrorKind};
 
 use async_std::sync::Sender as AsyncSender;
+use futures::prelude::*;
 
 #[cfg(unix)]
 use pnet_datalink;
@@ -9,6 +10,10 @@ use pnet_datalink;
 use ipconfig;
 
 use super::peer::{Direction, PeerEvent};
+
+// Convenience trait implementation, which helps to alias socket type
+pub trait TSocketAlias: AsyncRead + AsyncWrite + Send + Unpin {}
+impl<T: AsyncRead + AsyncWrite + Send + Unpin> TSocketAlias for T {}
 
 pub const CHUNK_SIZE: usize = 4096;
 

--- a/src/p2p/util.rs
+++ b/src/p2p/util.rs
@@ -43,6 +43,13 @@ pub async fn notify_waiting(sender_queue: &AsyncSender<PeerEvent>) {
         .await;
 }
 
+pub async fn notify_rejected(sender_queue: &AsyncSender<PeerEvent>) {
+    sender_queue
+        .to_owned()
+        .send(PeerEvent::TransferRejected)
+        .await;
+}
+
 pub fn time_to_notify(current_size: usize, total_size: usize) -> bool {
     if current_size >= ((total_size / 10) + CHUNK_SIZE * 256) {
         true


### PR DESCRIPTION
Three changes in this PR:
- Discovery behaviour will be bi-directional now. Both dialer and listener will exchange host information, which helps with network issues.
- Protobuf schema for transfer Answer will have different size and fields. This is actually fixing the hanging connection when sending answer to reject the file.
- Showing notifications when Dragit is waiting for the other device to accept or reject the file.