### PR TITLE
Update Flatpak metainfo for release 0.6.2

### DIFF
--- a/com.sireliah.Dragit.metainfo.xml
+++ b/com.sireliah.Dragit.metainfo.xml
@@ -15,6 +15,11 @@
     </p>
   </description>
   <releases>
+    <release version="0.6.2" date="2022-05-26">
+      <description>
+        <p>Updated dependencies</p>
+      </description>
+    </release>
     <release version="0.6.1" date="2021-06-27">
       <description>
         <p>Made Dragit check firewalld config when the application is started.</p>

--- a/static/com.sireliah.Dragit.yml
+++ b/static/com.sireliah.Dragit.yml
@@ -1,15 +1,17 @@
 app-id: com.sireliah.Dragit
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.rust-stable
 finish-args:
   - --share=network
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --device=dri
+  - --filesystem=home
+  - --system-talk-name=org.fedoraproject.FirewallD1
 build-options:
   append-path: "/usr/lib/sdk/rust-stable/bin"
 command: dragit
@@ -21,13 +23,11 @@ modules:
       - "*.a"
     build-commands:
       - install -Dm644 static/logo_icon_t.svg /app/share/icons/hicolor/scalable/apps/com.sireliah.Dragit.svg
-      - install -Dm644 static/logo_icon_t_128x128.png /app/share/icons/hicolor/128x128/apps/com.sireliah.Dragit.png
-      - install -Dm644 static/logo_icon_t_256x256.png /app/share/icons/hicolor/256x256/apps/com.sireliah.Dragit.png
       - install -Dm644 dragit.desktop /app/share/applications/com.sireliah.Dragit.desktop
       - install -Dm644 com.sireliah.Dragit.metainfo.xml /app/share/metainfo/com.sireliah.Dragit.metainfo.xml
       - cargo build --release --offline
       - install -Dm755 target/release/dragit /app/bin/dragit
     sources:
       - type: archive
-        url: https://github.com/sireliah/dragit/releases/download/v0.4.1/vendored_packages_v0.4.1.tar.gz
-        sha256: 71097576b03cbd2fa693ad4ac87414d52a360980560b345d69948c026e295f17
+        url: https://github.com/sireliah/dragit/releases/download/v0.6.1/vendored_packages_v0.6.1.tar.gz
+        sha256: 8a8e3bb62a8b21a597d4ef36f04793cd88d149475b67276708816f9076a4de64


### PR DESCRIPTION
Updates metainfo that will be used in Flatpak release. See [this repo](https://github.com/flathub/com.sireliah.Dragit).