### PR TITLE
Fix problematic close event for the firewall dialog

### DIFF
--- a/src/dnd/dialogs.rs
+++ b/src/dnd/dialogs.rs
@@ -89,7 +89,7 @@ impl FirewallDialog {
     }
 
     pub fn close(&self) {
-        self.0.hide();
         self.0.close();
+        self.0.hide();
     }
 }

--- a/src/dnd/mod.rs
+++ b/src/dnd/mod.rs
@@ -149,7 +149,6 @@ fn handle_firewall(window: &gtk::ApplicationWindow) -> Result<(), Box<dyn Error>
         // Please note that on some OS'es like Ubuntu, polkit will require password for querying firewalld D-Bus interface.
         let check_dialog = FirewallDialog::new_for_check(window);
         let check_response = check_dialog.run();
-        check_dialog.close();
 
         match check_response {
             gtk::ResponseType::Yes => {
@@ -159,6 +158,7 @@ fn handle_firewall(window: &gtk::ApplicationWindow) -> Result<(), Box<dyn Error>
                 if required_services.0 || required_services.1 {
                     let dialog = FirewallDialog::new_for_config(window, &config);
                     let response = dialog.run();
+                    check_dialog.close();
                     match response {
                         gtk::ResponseType::Yes => firewall.handle(required_services)?,
                         gtk::ResponseType::No => info!("Not checking firewall configuration"),


### PR DESCRIPTION
Inexplicable segfault from system gtk library was caused by firewall dialog being closed before the next one was opened.