### PR TITLE
Reduce sender memory usage

### DIFF
--- a/src/p2p/transfer/jobs.rs
+++ b/src/p2p/transfer/jobs.rs
@@ -1,9 +1,7 @@
 use std::fs;
-use std::io::{self, Read, Write};
+use std::io::{self, Write};
 use std::sync::mpsc::{Receiver, SyncSender};
 use std::thread::{self, JoinHandle};
-
-use crate::p2p::util::CHUNK_SIZE;
 
 pub fn spawn_write_file_job(
     receiver: Receiver<Vec<u8>>,
@@ -41,27 +39,5 @@ pub fn send_buffer(sender: &SyncSender<Vec<u8>>, buff: Vec<u8>) -> Result<(), io
             io::ErrorKind::NotConnected,
             "File reader disconnected",
         ))
-    })
-}
-
-pub fn spawn_read_file_job(
-    sender: SyncSender<Vec<u8>>,
-    mut file: fs::File,
-) -> JoinHandle<Result<(), io::Error>> {
-    thread::spawn(move || -> Result<(), io::Error> {
-        loop {
-            let mut buff = vec![0u8; CHUNK_SIZE * 32];
-            match file.read(&mut buff) {
-                Ok(n) if n > 0 => {
-                    send_buffer(&sender, buff[..n].to_vec())?;
-                }
-                Ok(_) => {
-                    send_buffer(&sender, vec![])?;
-                    break;
-                }
-                Err(e) => return Err(e),
-            }
-        }
-        Ok(())
     })
 }


### PR DESCRIPTION
Simplify the sender side by removing the thread for reading the file. This fixes the growing memory usage when reading the file.