### PR TITLE
Overwrite file/directory instead of extending it with timestamp

### DIFF
--- a/src/p2p/transfer/directory.rs
+++ b/src/p2p/transfer/directory.rs
@@ -187,7 +187,9 @@ pub async fn unzip_stream(
     let mut compat_reader = buf_reader.compat();
 
     let task = spawn(async move {
-        let base_path = Path::new(&target_path);
+        let base_path = Path::new(&target_path)
+            .parent()
+            .unwrap_or(Path::new(&target_path));
         let mut zip = ZipFileReader::new(&mut compat_reader);
         let mut counter: usize = 0;
         while !zip.finished() {
@@ -201,7 +203,9 @@ pub async fn unzip_stream(
 
                 if is_zip_dir(&path) {
                     debug!("Creating dir {:?}", path);
-                    create_dir(path).await?;
+                    if let Err(e) = create_dir(path).await {
+                        warn!("Could not create directory: {:?}", e);
+                    };
                 } else {
                     debug!("Creating file {:?}", path);
                     let mut file = File::create(&path).await?;

--- a/src/p2p/transfer/protocol.rs
+++ b/src/p2p/transfer/protocol.rs
@@ -1,4 +1,4 @@
-use async_std::fs::File;
+use async_std::fs::OpenOptions;
 use std::fmt;
 use std::fs::remove_file;
 use std::io::ErrorKind;
@@ -114,7 +114,13 @@ impl TransferPayload {
         size: usize,
         direction: &Direction,
     ) -> Result<usize, io::Error> {
-        let mut file = File::create(path).await?;
+        info!("Path: {}", path);
+        let mut file = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .open(path)
+            .await
+            .expect("Opening failed!");
         let mut counter: usize = 0;
         let mut current_size: usize = 0;
         loop {

--- a/tests/test_directory.rs
+++ b/tests/test_directory.rs
@@ -21,8 +21,8 @@ use common::{build_swarm, setup_logger};
 fn test_directory_transfer() {
     setup_logger();
     let (tx, mut rx) = bounded::<Multiaddr>(10);
-    let (peer1, sender, _, mut swarm1) = build_swarm();
-    let (_, _, _, mut swarm2) = build_swarm();
+    let (peer1, sender, _, mut swarm1, _tempdir1) = build_swarm();
+    let (_, _, _, mut swarm2, _tempdir2) = build_swarm();
 
     sender
         .try_send(TransferCommand::Accept("directory".to_string()))
@@ -133,24 +133,24 @@ fn test_directory_transfer() {
             let meta = fs::metadata(&path).expect("No file found");
             assert!(meta.is_dir());
             assert_eq!(
-                fs::metadata(Path::new(&path).join("test_dir/test.odt"))
+                fs::metadata(Path::new(&path).join("test.odt"))
                     .unwrap()
                     .len(),
                 8988
             );
             assert_eq!(
-                fs::metadata(Path::new(&path).join("test_dir/Der_Zauberberg.epub"))
+                fs::metadata(Path::new(&path).join("Der_Zauberberg.epub"))
                     .unwrap()
                     .len(),
                 659903
             );
             assert_eq!(
-                fs::metadata(Path::new(&path).join("test_dir/empty_file"))
+                fs::metadata(Path::new(&path).join("empty_file"))
                     .unwrap()
                     .len(),
                 0
             );
-            assert!(fs::metadata(Path::new(&path).join("test_dir/empty_dir/"))
+            assert!(fs::metadata(Path::new(&path).join("empty_dir/"))
                 .unwrap()
                 .is_dir());
         }

--- a/tests/test_file.rs
+++ b/tests/test_file.rs
@@ -22,8 +22,8 @@ fn test_file_transfer() {
 
     let file_path = "tests/data/file.txt".to_string();
     let (tx, mut rx) = bounded::<Multiaddr>(10);
-    let (peer1, sender, _, mut swarm1) = build_swarm();
-    let (_, _, _, mut swarm2) = build_swarm();
+    let (peer1, sender, _, mut swarm1, _tempdir1) = build_swarm();
+    let (_, _, _, mut swarm2, _tempdir2) = build_swarm();
 
     // File hash should be accepted from the beginning
     let file = fs::File::open(&file_path).unwrap();

--- a/tests/test_text.rs
+++ b/tests/test_text.rs
@@ -19,8 +19,8 @@ use common::{build_swarm, setup_logger};
 fn test_text_transfer() {
     setup_logger();
     let (tx, mut rx) = bounded::<Multiaddr>(10);
-    let (peer1, sender, _, mut swarm1) = build_swarm();
-    let (_, _, _, mut swarm2) = build_swarm();
+    let (peer1, sender, _, mut swarm1, _tempdir1) = build_swarm();
+    let (_, _, _, mut swarm2, _tempdir2) = build_swarm();
 
     // Text hash should be accepted from the beginning
     sender


### PR DESCRIPTION
This fixes also duplicate directory when transferring a folder, e.g. `~/Downloads/directory/directory/some-contents`.